### PR TITLE
Remove the "main" field from `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "A cli executable to run commands with the ENV variables loaded by dotenv-flow",
   "license": "MIT",
   "repository": "github:ovos/dotenv-flow-cli",
-  "main": "index.js",
   "bin": {
     "dotenv-flow": "./cli.js"
   },


### PR DESCRIPTION
Actually, the `index.js` file does not exist.
Hopefully, it is not required for `package.json`.