### PR TITLE
variable expansion using dotenv-expand

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,14 @@ Put `--` separator before the command if it takes additional arguments, otherwis
 ```bash
 $ dotenv-flow -- my-command -p something
 ```
+
+### Variable expansion
+To allow it to be a drop-in replacement for [dotenv-cli](https://github.com/motdotla/dotenv-cli) variable interpolation (expanding) is automatically enabled using [dotenv-expand](https://github.com/motdotla/dotenv-expand) under the hood.
+
+For example:
+```
+IP=127.0.0.1
+PORT=1234
+APP_URL=http://${IP}:${PORT}
+```
+Using the above example `.env` file, `process.env.APP_URL` will be resolved to `http://127.0.0.1:1234`.

--- a/cli.js
+++ b/cli.js
@@ -2,6 +2,7 @@
 const spawn = require('cross-spawn');
 const argv = require('minimist')(process.argv.slice(2));
 const dotenv = require('dotenv-flow');
+const dotenvExpand = require('dotenv-expand');
 
 function printHelp() {
   console.log(
@@ -19,7 +20,7 @@ if (argv.help) {
 }
 
 const path = argv.p;
-dotenv.config({ path });
+dotenvExpand.expand(dotenv.config({ path }));
 
 const command = argv._[0];
 if (!command) {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "cross-spawn": "^7.0.3",
+    "dotenv-expand": "*",
     "dotenv-flow": "*",
     "minimist": "^1.2.6"
   }


### PR DESCRIPTION
closes #2 

### Variable expansion
To allow it to be a drop-in replacement for [dotenv-cli](https://github.com/motdotla/dotenv-cli) variable interpolation (expanding) is automatically enabled using [dotenv-expand](https://github.com/motdotla/dotenv-expand) under the hood.

For example:
```
IP=127.0.0.1
PORT=1234
APP_URL=http://${IP}:${PORT}
```
Using the above example `.env` file, `process.env.APP_URL` will be resolved to `http://127.0.0.1:1234`.